### PR TITLE
Cargo with corelib

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,9 @@ jobs:
       - name: Install the Rust Toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
+          toolchain: nightly-2022-08-13
           targets: wasm32-unknown-unknown
+          components: rust-src
 
       - name: Install CE-Dev Toolchain
         shell: pwsh

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "demo"
+version = "0.1.0"
+authors = ["maddymakesgames <madelinemakesgames@gmail.com>", "Chris Moore <git@chrismoore.dev>"]
+edition = "2021"
+
+# rust-version = "2022-03-09"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/README.md
+++ b/README.md
@@ -25,3 +25,52 @@ This uses the include files from the [CE-Programming toolchain](https://github.c
 
 ## Release
 A GitHub Actions workflow is included. It produces an artifact containing the built 8xp and either the README-calc.md file, or if missing, this README.md file.
+
+# Getting LLVM Working
+
+## Approaching the same LLVM
+
+### CE-Programming/llvm-project
+As of writing (Oct 2025), [CE-Programming/llvm-project](https://github.com/CE-Programming/llvm-project) is at commit c74f71c. The artifacts built in their CI, released as a part of their [toolchain](https://github.com/CE-Programming/toolchain).
+```
+$ .\ez80-clang.exe --version --verbose
+clang version 15.0.0 (https://github.com/CE-Programming/llvm-project 23b78267b5d376b232475d0805a937e54b61e0d0)
+Target: ez80
+Thread model: posix
+
+$ git log 23b78267b5d376b232475d0805a937e54b61e0d0
+commit 23b78267b5d376b232475d0805a937e54b61e0d0
+Author: Adrien Bertrand <bertrand.adrien@gmail.com>
+Date:   Mon Jul 15 23:31:08 2024 -0600
+
+    fix CI: split linuxmac/win and adjust things (no tests on win)
+```
+
+The earliest commit in upstream LLVM before branching is 
+7c63cc1
+
+As of writing, [Comparing 7c63cca with CE-Programming/llvm-project:z80](https://github.com/CE-Programming/llvm-project/compare/7c63cc1..z80) is showing 274 changed files with 79,560 additions and 1,708 deletions.
+
+https://rustc-dev-guide.rust-lang.org/backend/updating-llvm.html
+
+The Rust project's LLVM is kept tidy with upstream, with tags for specific LLVM versions. There are two for LLVM 15:
+[rustc/15.0-2022-12-07 (fd949f3)](https://github.com/rust-lang/llvm-project/tree/rustc/15.0-2022-12-07)
+[rustc/15.0-2022-08-09 (a1232c4)](https://github.com/rust-lang/llvm-project/tree/rustc/15.0-2022-08-09)
+
+Checking for common ancestorship between rustc and CE-Programming reveals commit 7c63cc1 ()
+```
+$ git merge-base 23b7826 a1232c4
+7c63cc198b6de1adc32e0336cde5f1fe78ddc454
+
+$ git log 7c63cc198b6de1adc32e0336cde5f1fe78ddc454
+commit 7c63cc198b6de1adc32e0336cde5f1fe78ddc454
+Author: varconst <varconsteq@gmail.com>
+Date:   Fri Jun 3 20:39:00 2022 -0700
+
+    [libc++][ranges][NFC] Fix a patch link in ranges status.
+```
+
+# Alternative Solutions
+
+## W2C2 (Rust -> Wasi -> C -> eZ80)
+https://github.com/turbolent/w2c2

--- a/makefile
+++ b/makefile
@@ -20,27 +20,30 @@ RSFLAGS = --edition=2021 -C opt-level=0
 RS_EXTENSION = rs
 RSENTRY = $(wildcard $(SRCDIR)/lib.$(RS_EXTENSION))
 RSSOURCES = $(sort $(call rwildcard,$(SRCDIR),*.$(RS_EXTENSION)))
-LINK_RSSOURCES = $(call UPDIR_ADD,$(RSENTRY:$(SRCDIR)/%.$(RS_EXTENSION)=$(OBJDIR)/%.$(RS_EXTENSION).ll))
 
-override LTOFILES = $(LINK_CSOURCES) $(LINK_CPPSOURCES) $(LINK_RSSOURCES)
+override LTOFILES = $(LINK_CSOURCES) $(LINK_CPPSOURCES) $(if $(RSENTRY),incremental/rust.bc)
 
 include $(shell cedev-config --makefile)
 
 # The CE-Programming project uses .bc files for this step,
 # but we're using .ll files here so we could potentially map the target from wasm32 to ez80
 # bc/ir is just a matter of changing extensions (bc/ll) and --emit=llvm-(bc/ir)
-$(LINK_RSSOURCES): $(RSSOURCES) # $(EXTRA_HEADERS) $(MAKEFILE_LIST) $(DEPS)
+incremental/rust.bc: $(RSSOURCES)
 	$(Q)$(call MKDIR,$(@D))
-	$(Q)echo [compiling] $(call NATIVEPATH,$(RSENTRY)) due to modifed $(call NATIVEPATH,$?)
+	$(Q)echo "[compiling] $(call NATIVEPATH,$(RSENTRY)) due to modifed $(call NATIVEPATH,$?)"
 
 #   a good next step here would be figure out how to compile for ez80 directly
-	$(Q)rustc --target=wasm32-unknown-unknown --emit=llvm-ir -C debuginfo=0 $(RSFLAGS) $(call QUOTE_ARG,$(RSENTRY)) -o $(call QUOTE_ARG,$@)
+
+# nightly 2022-03-09 is the closest nightly to the ez80 LLVM branch of the CE-Programming project
+# using such a similar (major) LLVM version gets us a codegen clang crash instead of an IR syntax error
+	pwsh -NoProfile -Command '$$env:RUSTFLAGS="-C panic=abort -C debuginfo=0 --emit=llvm-ir -C opt-level=0"; cargo +nightly-2022-08-13 build --verbose -Z build-std=core --target=wasm32-unknown-unknown --release'
+
+#	pre-link the rust code to keep from incorporating the hashed, numerous, and undeterministic rust object filenames into the makefile rules
+#   yes the compiler_builtins glob is why we're using powershell
+	pwsh -NoProfile -Command 'ez80-link -o incremental/rust.bc @(Get-ChildItem .\target\wasm32-unknown-unknown\release\deps\*.ll | Where-Object { $$_.Name -NotLike "compiler_builtins-*.ll" }).FullName'
 
 #   building with this IR is a bit of a hack, but it works for this demo
 #   it emits (at least) two warnings due to the mismatching architectures:
 #   ez80 target from jac0bly/CE-Programming project's LLVM branch, and Rust's wasm32-unknown-unknown
 #   - Linking two modules of different data layouts
 #   - Linking two modules of different target triples
-
-#   no windows sed.. it just silences a warning anyway
-#	$(Q)sed -i "s/wasm32-unknown-unknown/ez80/" $(call QUOTE_ARG,$@)

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -6,4 +6,43 @@ extern "C" {
     pub fn os_DrawStatusBar();
     pub fn os_PutStrFull(str: *const [u8]);
     pub fn os_GetCSC() -> i8;
+    pub fn sprintf(
+        buffer: *mut u8,
+        format: *const u8,
+        args: ...
+    ) -> i32;
 }
+
+pub const DEBUG: bool = true;
+
+pub mod debug {
+    pub const DBG_OUT: *mut u8 = 0xFB0000 as *mut u8;
+    // pub const DBG_ERR: *mut u8 = 0xFC0000 as *mut u8;
+
+    pub fn clear_console() {
+        if !super::DEBUG { return; }
+
+        const CLEAR_CONSOLE_FLAG: *mut u8 = 0xFD0000 as *mut u8;
+        unsafe {
+            *CLEAR_CONSOLE_FLAG = 1;
+        }
+    }
+}
+
+// A Writer that emits to the debug console of CE-Emu
+// pub struct DebugWriter;
+
+// impl core::fmt::Write for DebugWriter {
+//     fn write_str(&mut self, s: &str) -> core::fmt::Result {
+//         if !DEBUG { return Ok(()); }
+
+//         let bytes = s.as_bytes();
+//         unsafe {
+//             sprintf(debug::DBG_OUT, b"%.*s\0".as_ptr(), bytes.len(), bytes.as_ptr());
+//         }
+//         Ok(())
+//     }
+// }
+
+
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,10 @@
 #![no_std]
 #![no_main]
 
+// extern crate core;
+
+// use core::fmt::Write;
+
 mod ffi;
 
 #[no_mangle]
@@ -9,6 +13,9 @@ unsafe fn rust_main() -> i8 {
     ffi::os_HomeUp();
     ffi::os_DrawStatusBar();
     ffi::os_PutStrFull(b"Hello from Rust!\x00");
+
+    // let _ = writeln!(ffi::DebugWriter, "Hello from DebugWriter!");
+
     while ffi::os_GetCSC() == 0 { }
 
     return 0;


### PR DESCRIPTION
Initial PR commit includes building with `nightly-2022-08-13` which gets us to LLVM 15, the same (major) version of LLVM as the CE-Programming project's toolchain. The build ultimately fails by crashing clang when translating the final linked IR to ASM, typically due to the inability to translate common instructions like `call`, or `ret`.

This PR is meant to hold any applicable research or progress into this issue: a modern eZ80 LLVM backend, a custom build of Rust for this the CE-Programming LLVM branch, etc.

```
$ ez80-link --version                   
LLVM (http://llvm.org/):
  LLVM version 15.0.0git
  Optimized build.
  Default target: x86_64-unknown-linux-gnu
  Host CPU: haswell

$ rustc +nightly-2022-08-13 --version -v
rustc 1.65.0-nightly (f22819bcc 2022-08-12)
binary: rustc
commit-hash: f22819bcce4abaff7d1246a56eec493418f9f4ee
commit-date: 2022-08-12
host: x86_64-unknown-linux-gnu
release: 1.65.0-nightly
LLVM version: 15.0.0
```